### PR TITLE
Add support for priority queues in RabbitMQ connector

### DIFF
--- a/src/RabbitMQConnector.php
+++ b/src/RabbitMQConnector.php
@@ -116,9 +116,9 @@ class RabbitMQConnector implements ConnectorInterface
      */
     protected function createQueue(AbstractConnection $connection, Pipe $pipe): AMQPChannel
     {
-        $pipe->setPropertyIfNull('exchange_type', AMQPExchangeType::FANOUT);
+        $pipe->setPropertyIfNull('exchange_type', AMQPExchangeType::DIRECT);
         $pipe->setPropertyIfNull(self::EXCHANGE, $pipe->getName());
-        // $pipe->setPropertyIfNull(self::ROUTING_KEY, $pipe->getName());
+        $pipe->setPropertyIfNull(self::ROUTING_KEY, $pipe->getName());
 
         // Get all queue properties
         $queueProperties = $pipe->getProperties();
@@ -160,7 +160,7 @@ class RabbitMQConnector implements ConnectorInterface
         */
         $channel->exchange_declare($pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty('exchange_type'), false, true, false);
 
-        $channel->queue_bind($pipe->getName(), $pipe->getProperty(self::EXCHANGE, $pipe->getName()));
+        $channel->queue_bind($pipe->getName(), $pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty(self::ROUTING_KEY, $pipe->getName()));
 
         return $channel;
     }

--- a/src/RabbitMQConnector.php
+++ b/src/RabbitMQConnector.php
@@ -116,9 +116,9 @@ class RabbitMQConnector implements ConnectorInterface
      */
     protected function createQueue(AbstractConnection $connection, Pipe $pipe): AMQPChannel
     {
-        $pipe->setPropertyIfNull('exchange_type', AMQPExchangeType::DIRECT);
+        $pipe->setPropertyIfNull('exchange_type', AMQPExchangeType::FANOUT);
         $pipe->setPropertyIfNull(self::EXCHANGE, $pipe->getName());
-        $pipe->setPropertyIfNull(self::ROUTING_KEY, $pipe->getName());
+        // $pipe->setPropertyIfNull(self::ROUTING_KEY, $pipe->getName());
 
         // Get all queue properties
         $queueProperties = $pipe->getProperties();
@@ -126,12 +126,13 @@ class RabbitMQConnector implements ConnectorInterface
         // Handle dead letter queue if present
         $dlq = $pipe->getDeadLetter();
         if (!empty($dlq)) {
+            $dlq->withProperty('exchange_type', AMQPExchangeType::FANOUT);
             $channelDlq = $this->createQueue($connection, $dlq);
             $channelDlq->close();
 
             // Add dead letter properties
             $queueProperties['x-dead-letter-exchange'] = $dlq->getProperty(self::EXCHANGE, $dlq->getName());
-            $queueProperties['x-dead-letter-routing-key'] = $dlq->getName();
+            // $queueProperties['x-dead-letter-routing-key'] = $dlq->getName();
             // $queueProperties['x-message-ttl'] = $dlq->getProperty('x-message-ttl', 3600 * 72*1000);
             // $queueProperties['x-expires'] = $dlq->getProperty('x-expires', 3600 * 72*1000 + 1000);
         }
@@ -159,7 +160,7 @@ class RabbitMQConnector implements ConnectorInterface
         */
         $channel->exchange_declare($pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty('exchange_type'), false, true, false);
 
-        $channel->queue_bind($pipe->getName(), $pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty(self::ROUTING_KEY, $pipe->getName()));
+        $channel->queue_bind($pipe->getName(), $pipe->getProperty(self::EXCHANGE, $pipe->getName()));
 
         return $channel;
     }

--- a/src/RabbitMQConnector.php
+++ b/src/RabbitMQConnector.php
@@ -112,10 +112,9 @@ class RabbitMQConnector implements ConnectorInterface
     /**
      * @param AbstractConnection $connection
      * @param Pipe $pipe
-     * @param bool $withExchange
      * @return AMQPChannel
      */
-    protected function createQueue(AbstractConnection $connection, Pipe $pipe, bool $withExchange = true): AMQPChannel
+    protected function createQueue(AbstractConnection $connection, Pipe $pipe): AMQPChannel
     {
         $pipe->setPropertyIfNull('exchange_type', AMQPExchangeType::DIRECT);
         $pipe->setPropertyIfNull(self::EXCHANGE, $pipe->getName());
@@ -159,9 +158,7 @@ class RabbitMQConnector implements ConnectorInterface
             durable: true // the exchange will survive server restarts
             auto_delete: false //the exchange won't be deleted once the channel is closed.
         */
-        if ($withExchange) {
-            $channel->exchange_declare($pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty('exchange_type'), false, true, false);
-        }
+        $channel->exchange_declare($pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty('exchange_type'), false, true, false);
 
         $channel->queue_bind($pipe->getName(), $pipe->getProperty(self::EXCHANGE, $pipe->getName()), $pipe->getProperty(self::ROUTING_KEY, $pipe->getName()));
 
@@ -171,10 +168,10 @@ class RabbitMQConnector implements ConnectorInterface
     /**
      * @throws Exception
      */
-    protected function lazyConnect(Pipe $pipe, $withExchange = true): array
+    protected function lazyConnect(Pipe $pipe): array
     {
         $driver = $this->getDriver();
-        $channel = $this->createQueue($driver, $pipe, $withExchange);
+        $channel = $this->createQueue($driver, $pipe);
 
         return [$driver, $channel];
     }
@@ -276,7 +273,7 @@ class RabbitMQConnector implements ConnectorInterface
                  * @var AbstractConnection $driver
                  * @var AMQPChannel $channel
                  */
-                list($driver, $channel) = $this->lazyConnect($pipe, false);
+                list($driver, $channel) = $this->lazyConnect($pipe);
 
                 /*
                     pipe: Queue from where to get the messages

--- a/src/RabbitMQConnector.php
+++ b/src/RabbitMQConnector.php
@@ -126,13 +126,12 @@ class RabbitMQConnector implements ConnectorInterface
         // Handle dead letter queue if present
         $dlq = $pipe->getDeadLetter();
         if (!empty($dlq)) {
-            $dlq->withProperty('exchange_type', AMQPExchangeType::FANOUT);
             $channelDlq = $this->createQueue($connection, $dlq);
             $channelDlq->close();
 
             // Add dead letter properties
             $queueProperties['x-dead-letter-exchange'] = $dlq->getProperty(self::EXCHANGE, $dlq->getName());
-            // $queueProperties['x-dead-letter-routing-key'] = $routingKey;
+            $queueProperties['x-dead-letter-routing-key'] = $dlq->getName();
             // $queueProperties['x-message-ttl'] = $dlq->getProperty('x-message-ttl', 3600 * 72*1000);
             // $queueProperties['x-expires'] = $dlq->getProperty('x-expires', 3600 * 72*1000 + 1000);
         }

--- a/src/RabbitMQConnector.php
+++ b/src/RabbitMQConnector.php
@@ -121,20 +121,25 @@ class RabbitMQConnector implements ConnectorInterface
         $pipe->setPropertyIfNull(self::EXCHANGE, $pipe->getName());
         $pipe->setPropertyIfNull(self::ROUTING_KEY, $pipe->getName());
 
-        $amqpTable = [];
+        // Get all queue properties
+        $queueProperties = $pipe->getProperties();
+
+        // Handle dead letter queue if present
         $dlq = $pipe->getDeadLetter();
         if (!empty($dlq)) {
             $dlq->withProperty('exchange_type', AMQPExchangeType::FANOUT);
             $channelDlq = $this->createQueue($connection, $dlq);
             $channelDlq->close();
 
-            $dlqProperties = $dlq->getProperties();
-            $dlqProperties['x-dead-letter-exchange'] = $dlq->getProperty(self::EXCHANGE, $dlq->getName());
-            // $dlqProperties['x-dead-letter-routing-key'] = $routingKey;
-            // $dlqProperties['x-message-ttl'] = $dlq->getProperty('x-message-ttl', 3600 * 72*1000);
-            // $dlqProperties['x-expires'] = $dlq->getProperty('x-expires', 3600 * 72*1000 + 1000);
-            $amqpTable = new AMQPTable($dlqProperties);
+            // Add dead letter properties
+            $queueProperties['x-dead-letter-exchange'] = $dlq->getProperty(self::EXCHANGE, $dlq->getName());
+            // $queueProperties['x-dead-letter-routing-key'] = $routingKey;
+            // $queueProperties['x-message-ttl'] = $dlq->getProperty('x-message-ttl', 3600 * 72*1000);
+            // $queueProperties['x-expires'] = $dlq->getProperty('x-expires', 3600 * 72*1000 + 1000);
         }
+
+        // Create AMQP table with all queue properties
+        $amqpTable = new AMQPTable($queueProperties);
 
         $channel = $connection->channel();
 


### PR DESCRIPTION
<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add support for priority queues in the RabbitMQ connector, allowing messages to be consumed based on their priority, and include test cases to verify this functionality.

### Why are these changes being made?
The addition of priority queues enhances the RabbitMQ connector by enabling message prioritization, which is important for scenarios where certain messages need to be processed before others based on their urgency or importance. The implemented test cases ensure that the new functionality works correctly by validating that messages with higher priorities are consumed before those with lower priorities.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->